### PR TITLE
Proper handling of negative temperatures

### DIFF
--- a/AM2321.cpp
+++ b/AM2321.cpp
@@ -130,8 +130,12 @@ public:
             return false;
         humidity     = buf[2] << 8;
         humidity    += buf[3];
-        temperature  = buf[4] << 8;
-        temperature += buf[5];
+        // check for negative temperate, copied from robtillaart's DHTlib
+	    temperature = word(buf[4] & 0x7F, buf[5]);
+	    if (buf[4] & 0x80) // negative temperature
+	    {
+	      temperature = -temperature;
+	    }
         return true;
     }
 };


### PR DESCRIPTION
taken from http://forum.arduino.cc/index.php?topic=310606.0

temperature MSB (Bit15) was not considered to indicate a positive or negative value. Hence when the bit was set the reported value was 32768 too high and still positive.